### PR TITLE
Raise CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(libuvc
   VERSION 0.0.7
   LANGUAGES C
@@ -24,6 +24,9 @@ endif()
 option(BUILD_EXAMPLE "Build example program" ON)
 option(BUILD_TEST "Build test program" OFF)
 option(ENABLE_UVC_DEBUGGING "Enable UVC debugging" OFF)
+
+set(LIBUVC_PAGE_SIZE "" CACHE STRING
+    "Optional max/common page size (bytes) applied to shared objects; leave empty to disable")
 
 set(libuvc_DESCRIPTION "A cross-platform library for USB video devices")
 set(libuvc_URL "https://github.com/libuvc/libuvc")
@@ -140,6 +143,10 @@ foreach(target_name IN LISTS UVC_TARGETS)
             PRIVATE
             ${log-lib}
     )
+  endif()
+  if(LIBUVC_PAGE_SIZE)
+    set_property(TARGET ${target_name} APPEND_STRING PROPERTY LINK_FLAGS
+      " -Wl,-z,max-page-size=${LIBUVC_PAGE_SIZE} -Wl,-z,common-page-size=${LIBUVC_PAGE_SIZE}")
   endif()
 endforeach()
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ in the build directory, or use a CMake GUI to make the desired changes.
 There is also `BUILD_EXAMPLE` and `BUILD_TEST` options to enable the compilation of `example` and `uvc_test` programs. To use them, replace the `cmake ..` command above with `cmake .. -DBUILD_TEST=ON -DBUILD_EXAMPLE=ON`.
 Then you can start them with `./example` and `./uvc_test` respectively. Note that you need OpenCV to build the later (for displaying image).
 
+### Building with 16 KB page size (Android compatibility)
+
+Some Android storefronts now require native libraries to be linked with 16 KB ELF page
+sizes. When cross-compiling libuvc with the Android NDK you can enable this alignment
+directly from CMake:
+
+```
+cmake .. -DLIBUVC_PAGE_SIZE=16384
+```
+
+This injects `-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384` into the
+generated link commands for the libuvc shared objects. Combine the option with your
+existing Android toolchain configuration flags (such as `-DANDROID_ABI` and
+`-DANDROID_PLATFORM`) to produce `.so` files that satisfy the Play Store requirement.
+
 ## Developing with libuvc
 
 The documentation for `libuvc` can currently be found at https://libuvc.github.io/.


### PR DESCRIPTION
## Summary
- bump cmake_minimum_required to 3.5 to match current policy requirements on recent CMake releases

## Testing
- cmake -S . -B build -DLIBUVC_PAGE_SIZE=16384 -DBUILD_EXAMPLE=OFF -DBUILD_TEST=OFF
- cmake --build build --config Release

------
https://chatgpt.com/codex/tasks/task_e_68d445ea5d1c832bb2113f36fd62d528